### PR TITLE
Memoize recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/command-score",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Yet another javascript fuzzy matching library",
   "main": "index.js",
   "directories": {

--- a/test.js
+++ b/test.js
@@ -69,7 +69,11 @@ describe("commandScore", function () {
         expect(commandScore("talent", "tadlent")).to.be.equal(0)
     });
 
-  it('should match - with " " characters', function () {
-    expect(commandScore('Auto-Advance', 'Auto Advance')).to.be.equal(0.9999)
-  })
+    it('should match - with " " characters', function () {
+        expect(commandScore('Auto-Advance', 'Auto Advance')).to.be.equal(0.9999)
+    });
+
+    it('should score long strings quickly', function () {
+        expect(commandScore("go to this is a really long label that is really longthis is a really long label that is really longthis is a really long label that is really longthis is a really long label that is really long", "this is a")).to.be.equal(0.891)
+    });
 });


### PR DESCRIPTION
The algorithm recurses inside of loops causing something
like quadratic run times based on the length of the command.
Testing revealed that most of the work is actually duplicated.

This fix adds a memoizing map to speed up the scoring of very
long strings.